### PR TITLE
fix: doc styles toml tag

### DIFF
--- a/docs/docs/config/styles.md
+++ b/docs/docs/config/styles.md
@@ -1,5 +1,5 @@
 # Styles 
-Denoted by `[keybinds.styles]` toml tag.
+Denoted by `[styles]` toml tag.
 
 ## Text
 Sets the primary text color used throughout the interface. Can be set using the `text` key.


### PR DESCRIPTION
Hello!
Seems like the tag is `[styles]` instead of `[keybinds.styles]`.  https://github.com/NucleoFusion/cruise/blob/8a32813675ce00e6c7844247bed1bbfea5c70a5a/dump.toml#L5

Also, I have tested this on version v1.1.0. Config with `[styles]` works. Config with `[keybinds.styles]` has no effect.

In the code (https://github.com/NucleoFusion/cruise/blob/8a32813675ce00e6c7844247bed1bbfea5c70a5a/internal/config/configModels.go#L5-L6), as I can see, the `keybinds` and `style` has the same "level"